### PR TITLE
Feat: 게시물 공유 기능 구현

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ django = "==5.0.7"
 djangorestframework = "==3.15.2"
 django-environ = "==0.11.2"
 drf-yasg = "==1.21.7"
+requests = "*"
 
 [dev-packages]
 flake8 = "==7.1.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dd889cbca11a04eddb0cc2341154fb26d65e72bdeb84a709cee9018813037d6a"
+            "sha256": "77b0d227dcab0545fcf2dd50f7af08a4a37dbfbe8ffb654c67c9260b74073724"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -24,6 +24,110 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==3.8.1"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b",
+                "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2024.7.4"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027",
+                "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087",
+                "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786",
+                "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8",
+                "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09",
+                "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185",
+                "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574",
+                "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e",
+                "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519",
+                "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898",
+                "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269",
+                "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3",
+                "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f",
+                "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6",
+                "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8",
+                "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a",
+                "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73",
+                "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc",
+                "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714",
+                "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2",
+                "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc",
+                "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce",
+                "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d",
+                "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e",
+                "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6",
+                "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269",
+                "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
+                "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d",
+                "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a",
+                "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4",
+                "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77",
+                "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d",
+                "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0",
+                "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed",
+                "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068",
+                "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac",
+                "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25",
+                "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8",
+                "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab",
+                "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26",
+                "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2",
+                "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db",
+                "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f",
+                "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5",
+                "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99",
+                "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c",
+                "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d",
+                "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811",
+                "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa",
+                "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a",
+                "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03",
+                "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b",
+                "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04",
+                "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c",
+                "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001",
+                "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458",
+                "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389",
+                "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99",
+                "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985",
+                "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537",
+                "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238",
+                "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f",
+                "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d",
+                "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796",
+                "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a",
+                "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143",
+                "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8",
+                "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c",
+                "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5",
+                "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5",
+                "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711",
+                "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4",
+                "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6",
+                "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c",
+                "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7",
+                "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4",
+                "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b",
+                "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae",
+                "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12",
+                "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c",
+                "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae",
+                "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8",
+                "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887",
+                "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b",
+                "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4",
+                "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f",
+                "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
+                "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33",
+                "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519",
+                "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==3.3.2"
         },
         "django": {
             "hashes": [
@@ -60,6 +164,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.6'",
             "version": "==1.21.7"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac",
+                "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.8"
         },
         "inflection": {
             "hashes": [
@@ -143,6 +255,15 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.0.2"
         },
+        "requests": {
+            "hashes": [
+                "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+                "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==2.32.3"
+        },
         "sqlparse": {
             "hashes": [
                 "sha256:773dcbf9a5ab44a090f3441e2180efe2560220203dc2f8c0b0fa141e18b505e4",
@@ -159,6 +280,14 @@
             "markers": "python_version < '3.11'",
             "version": "==4.12.2"
         },
+        "tzdata": {
+            "hashes": [
+                "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd",
+                "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==2024.1"
+        },
         "uritemplate": {
             "hashes": [
                 "sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0",
@@ -166,6 +295,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==4.1.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
+                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.2"
         }
     },
     "develop": {
@@ -213,6 +350,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+                "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+            ],
+            "markers": "platform_system == 'Windows'",
+            "version": "==0.4.6"
         },
         "distlib": {
             "hashes": [

--- a/article/urls.py
+++ b/article/urls.py
@@ -1,7 +1,12 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 
-from article.views import ArticleLikeAPIView, ArticlesView, ArticleDetailView
+from article.views import (
+    ArticleLikeAPIView,
+    ArticleShareAPIView,
+    ArticlesView,
+    ArticleDetailView,
+)
 
 app_name = "article"
 router = DefaultRouter()
@@ -20,6 +25,11 @@ urlpatterns = [
     path(
         "<int:article_id>/like/",
         ArticleLikeAPIView.as_view(),
+        name="article-like",
+    ),
+    path(
+        "<int:article_id>/share/",
+        ArticleShareAPIView.as_view(),
         name="article-like",
     ),
 ]

--- a/article/urls.py
+++ b/article/urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
     path(
         "<int:article_id>/share/",
         ArticleShareAPIView.as_view(),
-        name="article-like",
+        name="article-share",
     ),
 ]
 

--- a/article/utils/article_site_dict.py
+++ b/article/utils/article_site_dict.py
@@ -1,0 +1,7 @@
+article_site_dict = {
+    """ article 관련 외부 api 요청용 url 저장 dict """
+    "facebook": "https://www.facebook.com/",
+    "twitter": "https://www.twitter.com/",
+    "instagram": "https://www.instagram.com/",
+    "threads": "https://www.threads.net/",
+}

--- a/article/views/__init__.py
+++ b/article/views/__init__.py
@@ -1,3 +1,4 @@
 from .article_like_views import ArticleLikeAPIView
+from .article_share_view import ArticleShareAPIView
 from .article_detail_view import ArticleDetailView
 from .article_list_view import ArticlesView

--- a/article/views/article_like_views.py
+++ b/article/views/article_like_views.py
@@ -1,3 +1,4 @@
+import requests
 from django.http import Http404
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -7,6 +8,7 @@ from rest_framework.permissions import IsAuthenticated
 from django.shortcuts import get_object_or_404
 
 from article.models import Article
+from article.utils.article_site_dict import article_site_dict
 
 
 class ArticleLikeAPIView(APIView):
@@ -37,6 +39,25 @@ class ArticleLikeAPIView(APIView):
                     {"msg": "해당하는 게시글이 없습니다."},
                     status=status.HTTP_404_NOT_FOUND,
                 )
+
+            # 외부 api 요청용 url 제작
+            # 현재는 주석 처리
+            # url = ""
+            # if article.type in article_site_dict:
+            #     url = article_site_dict[article.type] + f"/like/{article.content_id}"
+            # else:
+            #     return Response(
+            #         {"msg": "존재하지 않는 사이트입니다."},
+            #         status=status.HTTP_400_BAD_REQUEST,
+            #     )
+
+            # 외부 api 호출
+            # response = requests.post(url)
+            # if response.status_code != 200:
+            #     return Response(
+            #         {"msg": "해당 사이트의 좋아요 작업에 실패했습니다."},
+            #         status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            #     )
 
             # like_cnt 증가
             article.like_cnt += 1

--- a/article/views/article_share_view.py
+++ b/article/views/article_share_view.py
@@ -1,0 +1,82 @@
+import requests
+from django.http import Http404
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAuthenticated
+from django.shortcuts import get_object_or_404
+
+from article.models import Article
+from article.utils.article_site_dict import article_site_dict
+
+
+class ArticleShareAPIView(APIView):
+    # permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        """
+        GET : /articles/:id/share/
+        게시물 공유 버튼 클릭 시, share_cnt 1씩 증가
+
+        TODO: 나중에 에러 메시지 한 파일에 모아서 관리할 것
+        TODO: 해당하는 사이트의 공유 기능과 연결하기
+        """
+        try:
+            # path param으로 article_id 추출
+            article_id = kwargs.get("article_id")
+
+            # 게시글 id가 전달되지 않을 시, 오류
+            if not article_id:
+                raise ValidationError()
+
+            # 해당하는 article 객체 조회
+            # 없을 시, 404 Error 발생
+            try:
+                article = get_object_or_404(Article, id=article_id)
+            except Http404:
+                return Response(
+                    {"msg": "해당하는 게시글이 없습니다."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
+            # 외부 api 요청용 url 제작
+            # 현재는 주석 처리
+            # url = ""
+            # if article.type in article_site_dict:
+            #     url = article_site_dict[article.type] + f"/share/{article.content_id}"
+            # else:
+            #     return Response(
+            #         {"msg": "존재하지 않는 사이트입니다."},
+            #         status=status.HTTP_400_BAD_REQUEST,
+            #     )
+
+            # 외부 api 호출
+            # response = requests.post(url)
+            # if response.status_code != 200:
+            #     return Response(
+            #         {"msg": "해당 사이트와의 공유 작업에 실패했습니다."},
+            #         status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            #     )
+
+            # share_cnt 증가
+            article.share_cnt += 1
+            article.save()
+
+            # 성공 시, 200 응답
+            return Response(status=status.HTTP_200_OK)
+
+        # 에러 처리
+        except ValidationError as e:
+            # 잘못된 요청 시(400)
+            return Response(
+                {"msg": f"{e.detail} 게시글 번호가 필요합니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        except Exception as e:
+            # 그 외 예외 처리(500)
+            return Response(
+                {"msg": f"{str(e)} 오류가 발생했습니다. 다시 시도해주세요."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )


### PR DESCRIPTION
## 작업 내용
: 유저가 게시물 공유하기 버튼 클릭 시, 게시물의 share_cnt가 1 증가합니다.
(본래는 외부 api 호출되나, 이번에는 생략(주석화))

- 관련 API 명세서 작성
- 게시물 공유 cnt 1 증가 기능 구현
   - ArticleShareAPIView 생성 (GET) 및 등록
   - API 연동 코드 제작 (현재 주석화) => ArticleLikeAPIView에도 추가
   - 외부 api 통신을 위한 패키지(requests) 설치
   - 사이트 url 관리를 위한 utils 폴더, article_site_dict.py 생성
       - dict으로 관리(article.type 값이 key, 사이트 url이 value)  
   - article > urls.py에 등록
## 관련 이슈
- [[Feat] 게시물 공유 기능 구현](https://github.com/wanted-pre-onboarding-backend-django/feed-flow/issues/11)