### PR TITLE
Feat: 게시물의 해시태그 기반 통계 기능 구현

### DIFF
--- a/article/admin/article_admin.py
+++ b/article/admin/article_admin.py
@@ -10,6 +10,9 @@ class ArticleAdmin(admin.ModelAdmin):
         "type",
         "content_id",
         "user",
+        "view_cnt",
+        "like_cnt",
+        "share_cnt",
         "created_at",
     )
 

--- a/article/serializers/__init__.py
+++ b/article/serializers/__init__.py
@@ -1,2 +1,4 @@
 from .aricle_detail_serializer import ArticleDetailSerializer
 from .article_list_serializer import ArticleListSerializer
+from .article_statistics_serializer import ArticleStatisticsSerializer
+from .article_statistics_serializer import StatisticsDateSerializer

--- a/article/serializers/article_statistics_serializer.py
+++ b/article/serializers/article_statistics_serializer.py
@@ -11,6 +11,7 @@ class ArticleStatisticsSerializer(serializers.Serializer):
     Serializer definition for ArticleStatisticsSerializer.
     : StatisticsAPIView에서 입력받은 쿼리 파라미터를 검증하기 위해 사용됩니다.
     """
+
     hashtag = serializers.CharField(
         required=False,
         allow_blank=True,
@@ -52,9 +53,9 @@ class ArticleStatisticsSerializer(serializers.Serializer):
         """
         type 필드의 유효성을 검사하고, 해당하는 Trunc 함수를 반환합니다.
         """
-        if value == 'date':
+        if value == "date":
             return TruncDay
-        elif value == 'hour':
+        elif value == "hour":
             return TruncHour
         else:
             raise serializers.ValidationError("Unsupported date_type")
@@ -70,11 +71,13 @@ class ArticleStatisticsSerializer(serializers.Serializer):
             data["hashtag"] = request.user.account
 
         # start_date와 end_date의 일관성 검사
-        start_date = data.get('start')
-        end_date = data.get('end')
+        start_date = data.get("start")
+        end_date = data.get("end")
 
         if start_date and end_date and start_date >= end_date:
-            raise serializers.ValidationError("The start date must be before the end date.")
+            raise serializers.ValidationError(
+                "The start date must be before the end date."
+            )
 
         return data
 
@@ -84,5 +87,6 @@ class StatisticsDateSerializer(serializers.Serializer):
     Serializer definition for StatisticsDateSerializer.
     : 날짜와 시간 단위의 통계 데이터를 직렬화하는데 사용됩니다.
     """
+
     datetime = serializers.DateTimeField(format="%Y-%m-%d %H:%M")
     count = serializers.IntegerField()

--- a/article/serializers/article_statistics_serializer.py
+++ b/article/serializers/article_statistics_serializer.py
@@ -1,4 +1,8 @@
 from datetime import datetime, timedelta
+
+from django.db.models.functions import TruncDay, TruncHour
+from django.utils import timezone
+
 from rest_framework import serializers
 
 
@@ -25,6 +29,54 @@ class ArticleStatisticsSerializer(serializers.Serializer):
         choices=["count", "view_count", "like_count", "share_count"],
         required=False,
         default="count",
+    )
+
+    def validate_start(self, value):
+        """
+        start_date 필드를 유효성 검사하고, 타임존을 적용하여 datetime 객체로 변환합니다.
+        또한, start 날짜가 현재 날짜 이전인지 확인합니다.
+        """
+        if value >= datetime.now().date():
+            raise serializers.ValidationError("The start date must be before today.")
+
+        # 날짜를 타임존이 적용된 datetime 객체로 변환
+        return timezone.make_aware(datetime.combine(value, datetime.min.time()))
+
+    def validate_end(self, value):
+        """
+        end_date 필드를 유효성 검사하고, 타임존을 적용하여 datetime 객체로 변환합니다.
+        """
+        return timezone.make_aware(datetime.combine(value, datetime.max.time()))
+
+    def validate_type(self, value):
+        """
+        type 필드의 유효성을 검사하고, 해당하는 Trunc 함수를 반환합니다.
+        """
+        if value == 'date':
+            return TruncDay
+        elif value == 'hour':
+            return TruncHour
+        else:
+            raise serializers.ValidationError("Unsupported date_type")
+
+    def validate(self, data):
+        """
+        해시태그가 입력되지 않은 경우 사용자 계정명을 해시태그로 설정합니다.
+        start_date와 end_date의 논리적 일관성을 검사합니다.
+        """
+        # 사용자의 계정명을 해시태그로 설정
+        request = self.context.get("request")
+        if not data.get("hashtag") and request and hasattr(request, "user"):
+            data["hashtag"] = request.user.account
+
+        # start_date와 end_date의 일관성 검사
+        start_date = data.get('start')
+        end_date = data.get('end')
+
+        if start_date and end_date and start_date >= end_date:
+            raise serializers.ValidationError("The start date must be before the end date.")
+
+        return data
 
 
 class StatisticsDateSerializer(serializers.Serializer):

--- a/article/serializers/article_statistics_serializer.py
+++ b/article/serializers/article_statistics_serializer.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta
+from rest_framework import serializers
+
+
+class ArticleStatisticsSerializer(serializers.Serializer):
+    """
+    Serializer definition for ArticleStatisticsSerializer.
+    : StatisticsAPIView에서 입력받은 쿼리 파라미터를 검증하기 위해 사용됩니다.
+    """
+    hashtag = serializers.CharField(
+        required=False,
+        allow_blank=True,
+    )
+    type = serializers.ChoiceField(
+        choices=["date", "hour"],
+        required=True,
+    )
+    start = serializers.DateField(
+        default=lambda: datetime.now().date() - timedelta(days=7),
+    )
+    end = serializers.DateField(
+        default=lambda: datetime.now().date(),
+    )
+    value = serializers.ChoiceField(
+        choices=["count", "view_count", "like_count", "share_count"],
+        required=False,
+        default="count",
+
+
+class StatisticsDateSerializer(serializers.Serializer):
+    """
+    Serializer definition for StatisticsDateSerializer.
+    : 날짜와 시간 단위의 통계 데이터를 직렬화하는데 사용됩니다.
+    """
+    datetime = serializers.DateTimeField(format="%Y-%m-%d %H:%M")
+    count = serializers.IntegerField()

--- a/article/urls.py
+++ b/article/urls.py
@@ -7,6 +7,7 @@ from article.views import (
     ArticlesView,
     ArticleDetailView,
 )
+from article.views.article_statistics_api_view import StatisticsAPIView
 
 app_name = "article"
 router = DefaultRouter()
@@ -32,6 +33,7 @@ urlpatterns = [
         ArticleShareAPIView.as_view(),
         name="article-share",
     ),
+    path("statistics", StatisticsAPIView.as_view()),
 ]
 
 urlpatterns += router.urls

--- a/article/views/__init__.py
+++ b/article/views/__init__.py
@@ -2,3 +2,4 @@ from .article_like_views import ArticleLikeAPIView
 from .article_share_view import ArticleShareAPIView
 from .article_detail_view import ArticleDetailView
 from .article_list_view import ArticlesView
+from .article_statistics_api_view import StatisticsAPIView

--- a/article/views/article_statistics_api_view.py
+++ b/article/views/article_statistics_api_view.py
@@ -1,0 +1,53 @@
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from article.models import Article
+from article.serializers import ArticleStatisticsSerializer, StatisticsDateSerializer
+
+
+class StatisticsAPIView(APIView):
+    """
+    Article 통계 정보 조회 API
+
+    이 API는 특정 해시태그와 기간에 따른 게시물 통계를 조회합니다.
+    클라이언트는 해시태그, 조회 유형(type), 기간(start, end), 통계 값(value)을 지정할 수 있습니다.
+    """
+    serializer_class = ArticleStatisticsSerializer
+
+    @swagger_auto_schema(
+        operation_summary="Article 통계 정보 조회 API",
+        query_serializer=serializer_class,
+        responses={
+            status.HTTP_200_OK: StatisticsDateSerializer,
+        },
+    )
+    def get(self, request, *args, **kwargs):
+        """
+        GET : /articles/statistics/
+
+        - Parameters:
+            - hashtag (string, optional): 조회할 해시태그. 없으면 계정명 사용.
+            - type (string, required): 'date' 또는 'hour' 단위 조회.
+            - start (date, optional): 조회 시작 날짜. 기본값 7일 전.
+            - end (date, optional): 조회 종료 날짜. 기본값 오늘.
+            - value (string, optional): 통계 유형. 'count'(기본값), 'view_count', 'like_count', 'share_count'.
+
+        클라이언트가 제공한 쿼리 파라미터를 기반으로 통계 정보를 조회하고 반환합니다.
+        """
+        serializer = self.serializer_class(data=request.GET)
+        if serializer.is_valid():
+            try:
+                hashtag = serializer.validated_data['hashtag']
+                value = serializer.validated_data['value']
+                aggregation_type = serializer.validated_data['type']
+                start_date = serializer.validated_data['start']
+                end_date = serializer.validated_data['end']
+                return Response(serializer.data, status=status.HTTP_200_OK)
+
+            except Exception as e:
+                print("An error occurred:", str(e))
+                return Response({"detail": "An error occurred while processing your request."}, status=500)
+        else:
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/article/views/article_statistics_api_view.py
+++ b/article/views/article_statistics_api_view.py
@@ -17,6 +17,7 @@ class StatisticsAPIView(APIView):
     이 API는 특정 해시태그와 기간에 따른 게시물 통계를 조회합니다.
     클라이언트는 해시태그, 조회 유형(type), 기간(start, end), 통계 값(value)을 지정할 수 있습니다.
     """
+
     serializer_class = ArticleStatisticsSerializer
     permission_classes = [IsAuthenticated]
 
@@ -40,14 +41,16 @@ class StatisticsAPIView(APIView):
 
         클라이언트가 제공한 쿼리 파라미터를 기반으로 통계 정보를 조회하고 반환합니다.
         """
-        serializer = self.serializer_class(data=request.GET, context={'request': request})
+        serializer = self.serializer_class(
+            data=request.GET, context={"request": request}
+        )
         if serializer.is_valid():
             try:
-                hashtag = serializer.validated_data['hashtag']
-                value = serializer.validated_data['value']
-                aggregation_type = serializer.validated_data['type']
-                start_date = serializer.validated_data['start']
-                end_date = serializer.validated_data['end']
+                hashtag = serializer.validated_data["hashtag"]
+                value = serializer.validated_data["value"]
+                aggregation_type = serializer.validated_data["type"]
+                start_date = serializer.validated_data["start"]
+                end_date = serializer.validated_data["end"]
 
                 queryset = self.get_filtered_queryset(start_date, end_date, hashtag)
 
@@ -57,7 +60,10 @@ class StatisticsAPIView(APIView):
 
             except Exception as e:
                 print("An error occurred:", str(e))
-                return Response({"detail": "An error occurred while processing your request."}, status=500)
+                return Response(
+                    {"detail": "An error occurred while processing your request."},
+                    status=500,
+                )
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -89,11 +95,9 @@ class StatisticsAPIView(APIView):
         """
 
         # aggregation_type을 사용하여 'created_at' 필드를 날짜 또는 시간 단위로 그룹화하고, 이를 'datetime' 필드로 추가합니다.
-        annotated_queryset = (
-            queryset
-            .annotate(datetime=aggregation_type("created_at"))
-            .values("datetime")
-        )
+        annotated_queryset = queryset.annotate(
+            datetime=aggregation_type("created_at")
+        ).values("datetime")
 
         # value에 따른 집계 방법 선택: count인 경우 개수, view_count/like_count/share_count인 경우 합계를 계산
         if value == "count":

--- a/article/views/article_statistics_api_view.py
+++ b/article/views/article_statistics_api_view.py
@@ -1,5 +1,8 @@
+from django.db.models import Count, Q, Sum
+
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -15,6 +18,7 @@ class StatisticsAPIView(APIView):
     클라이언트는 해시태그, 조회 유형(type), 기간(start, end), 통계 값(value)을 지정할 수 있습니다.
     """
     serializer_class = ArticleStatisticsSerializer
+    permission_classes = [IsAuthenticated]
 
     @swagger_auto_schema(
         operation_summary="Article 통계 정보 조회 API",
@@ -36,7 +40,7 @@ class StatisticsAPIView(APIView):
 
         클라이언트가 제공한 쿼리 파라미터를 기반으로 통계 정보를 조회하고 반환합니다.
         """
-        serializer = self.serializer_class(data=request.GET)
+        serializer = self.serializer_class(data=request.GET, context={'request': request})
         if serializer.is_valid():
             try:
                 hashtag = serializer.validated_data['hashtag']

--- a/article/views/article_statistics_api_view.py
+++ b/article/views/article_statistics_api_view.py
@@ -44,6 +44,8 @@ class StatisticsAPIView(APIView):
                 aggregation_type = serializer.validated_data['type']
                 start_date = serializer.validated_data['start']
                 end_date = serializer.validated_data['end']
+
+                queryset = self.get_filtered_queryset(start_date, end_date, hashtag)
                 return Response(serializer.data, status=status.HTTP_200_OK)
 
             except Exception as e:
@@ -51,3 +53,13 @@ class StatisticsAPIView(APIView):
                 return Response({"detail": "An error occurred while processing your request."}, status=500)
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def get_filtered_queryset(self, start_date, end_date, hashtag):
+        """
+        주어진 날짜 범위와 해시태그에 따라 필터링된 게시물의 QuerySet을 반환합니다.
+        """
+        q = Q(created_at__range=(start_date, end_date)) & Q(hashtag__name=hashtag)
+        filtered_queryset = Article.objects.prefetch_related("hashtag").filter(q)
+
+        return filtered_queryset
+


### PR DESCRIPTION
## 작업 내용
- `StatisticsAPIView` 구현
  - : 특정 해시태그와 기간에 따른 게시물의 통계 정보를 조회합니다.
  - 클라이언트는 쿼리 파라미터를 통해 조회하려는 해시태그, 기간, 통계 유형 등을 지정할 수 있습니다.
  - get_statistics 함수 구현
    - : Django의 ORM 내에서 날짜 필드를 일(day)/시간(hour) 단위로 잘라내어 집계할 때 사용되는 함수인 `TruncDay`, `TruncHour` 사용
- 입력받은 쿼리 파라미터를 검증하기 위한 `ArticleStatisticsSerializer` 구현
  - 요구사항을 기반으로 field의 유효성 검사 함수 구현

<details>
  <summary> API Swagger</summary>

  ![image](https://github.com/user-attachments/assets/bf5c4857-e1c1-46b0-8937-9b2474ec408f)
</details>

<details>
  <summary> Success Case</summary>
  
  <img width="1552" alt="Success" src="https://github.com/user-attachments/assets/353916ff-e4ab-4d57-8d27-a62757361a4b">
</details>

<details>
  <summary> Error Case</summary>

  <img width="1552" alt="Error" src="https://github.com/user-attachments/assets/225f5c0a-c88e-444c-ab8b-db584f220ab4">

</details>

## 관련 이슈
- #9 